### PR TITLE
fix: debugging github releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /workspace
+      - restore_cache: *restore-deps-cache-rust
       - run: /workspace/semantic-rs-linux --write=yes --release=yes --asset /workspace/semantic-rs-linux --asset Changelog.md
+      - save_cache: *restore-deps-cache-rust
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /workspace
-      - run: /workspace/semantic-rs-linux --write=no --release=no --branch=$CIRCLE_BRANCH --asset /workspace/semantic-rs-linux --asset Changelog.md
+      - run: /workspace/semantic-rs-linux --write=no --release=no --branch=$CIRCLE_BRANCH --asset /workspace/semantic-rs-linux --asset Changelog.md --force-https
 
   release:
     <<: *defaults
@@ -98,7 +98,7 @@ jobs:
       - attach_workspace:
           at: /workspace
       - restore_cache: *restore-deps-cache-rust
-      - run: /workspace/semantic-rs-linux --write=yes --release=yes --asset /workspace/semantic-rs-linux --asset Changelog.md
+      - run: /workspace/semantic-rs-linux --write=yes --release=yes --asset /workspace/semantic-rs-linux --asset Changelog.md --force-https
       - save_cache: *restore-deps-cache-rust
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,25 +107,25 @@ workflows:
     jobs:
       - test:
           filters: *filter-only-semantic-pr
-      - install:
+      - build-linux-release:
           filters: *filter-only-semantic-pr
       - release-dry-run:
           filters: *filter-only-semantic-pr
           requires:
             - test
-            - install
+            - build-linux-release
 
   release:
     jobs:
       - test:
           filters: *filter-only-master
-      - install:
+      - build-linux-release:
           filters: *filter-only-master
       - release-dry-run:
           filters: *filter-only-master
           requires:
             - test
-            - install
+            - build-linux-release
       - hold:
           filters: *filter-only-master
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: cargo clippy
       - run: cargo fmt -- --check
 
-  install:
+  build-linux-release:
     <<: *defaults
     docker:
       - image: ekidd/rust-musl-builder
@@ -73,10 +73,11 @@ jobs:
       - restore_cache: *restore-deps-cache-musl
       - run: cargo build --release
       - save_cache: *save-deps-cache-musl
+      - run: mv target/x86_64-unknown-linux-musl/release/semantic-rs ./semantic-rs-linux
       - persist_to_workspace:
-          root: target/x86_64-unknown-linux-musl/release
+          root: .
           paths:
-            - semantic-rs
+            - semantic-rs-linux
 
   release-dry-run:
     <<: *defaults
@@ -86,7 +87,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /workspace
-      - run: /workspace/semantic-rs --write=no --release=no --branch=$CIRCLE_BRANCH --asset /workspace/semantic-rs --asset Changelog.md
+      - run: /workspace/semantic-rs-linux --write=no --release=no --branch=$CIRCLE_BRANCH --asset /workspace/semantic-rs-linux --asset Changelog.md
 
   release:
     <<: *defaults
@@ -96,7 +97,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /workspace
-      - run: /workspace/semantic-rs --write=yes --release=yes --asset /workspace/semantic-rs --asset Changelog.md
+      - run: /workspace/semantic-rs-linux --write=yes --release=yes --asset /workspace/semantic-rs-linux --asset Changelog.md
 
 workflows:
   version: 2

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
 
     pub write_mode: bool,
     pub release_mode: bool,
+    pub force_https: bool,
 
     pub repository: Repository,
     pub signature: Signature<'static>,
@@ -49,6 +50,7 @@ pub struct ConfigBuilder {
 
     write_mode: bool,
     release_mode: bool,
+    force_https: bool,
 
     repository: Option<Repository>,
     signature: Option<Signature<'static>>,
@@ -68,6 +70,7 @@ impl ConfigBuilder {
             repository_path: None,
             write_mode: false,
             release_mode: false,
+            force_https: false,
             repository: None,
             signature: None,
             gh_token: None,
@@ -103,6 +106,11 @@ impl ConfigBuilder {
     }
 
     pub fn write(&mut self, mode: bool) -> &mut Self {
+        self.write_mode = mode;
+        self
+    }
+
+    pub fn force_https(&mut self, mode: bool) -> &mut Self {
         self.write_mode = mode;
         self
     }
@@ -145,6 +153,7 @@ impl ConfigBuilder {
             repository_path: self.repository_path.unwrap(),
             write_mode: self.write_mode,
             release_mode: self.release_mode,
+            force_https: self.force_https,
             repository: self.repository.unwrap(),
             signature: self.signature.unwrap(),
             gh_token: self.gh_token,

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ impl ConfigBuilder {
     }
 
     pub fn force_https(&mut self, mode: bool) -> &mut Self {
-        self.write_mode = mode;
+        self.force_https = mode;
         self
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -172,10 +172,6 @@ pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
     let mut cbs = RemoteCallbacks::new();
     let mut opts = PushOptions::new();
 
-    if let Some(remote) = remote.url() {
-        log::info!("Current remote: {}", remote);
-    }
-
     if is_https_remote(remote.url()) {
         cbs.credentials(|_url, _username, _allowed| Cred::userpass_plaintext(&token.unwrap(), ""));
         opts.remote_callbacks(cbs);

--- a/src/git.rs
+++ b/src/git.rs
@@ -172,7 +172,9 @@ pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
     let mut cbs = RemoteCallbacks::new();
     let mut opts = PushOptions::new();
 
-    log::info!("Current remote: {}", remote.url());
+    if let Some(remote) = remote.url() {
+        log::info!("Current remote: {}", remote);
+    }
 
     if is_https_remote(remote.url()) {
         cbs.credentials(|_url, _username, _allowed| Cred::userpass_plaintext(&token.unwrap(), ""));

--- a/src/git.rs
+++ b/src/git.rs
@@ -84,7 +84,7 @@ fn create_tag(config: &Config, tag_name: &str, message: &str) -> Result<(), git2
         .map(|_| ())
 }
 
-fn is_https_remote(maybe_remote: Option<&str>) -> bool {
+pub fn is_https_remote(maybe_remote: Option<&str>) -> bool {
     if let Some(remote) = maybe_remote {
         remote.starts_with("https://")
     } else {
@@ -163,6 +163,13 @@ pub fn get_remote_url(config: &Config, remote: &str) -> Result<Option<String>, E
         .find_remote(remote)?
         .url()
         .map(ToOwned::to_owned))
+}
+
+pub fn set_remote_url(config: &mut Config, remote: &str, url: &str) -> Result<(), Error> {
+    let repo = &mut config.repository;
+    repo.remote_set_url(remote, url)?;
+    repo.remote_set_pushurl(remote, Some(url))?;
+    Ok(())
 }
 
 pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -172,6 +172,8 @@ pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
     let mut cbs = RemoteCallbacks::new();
     let mut opts = PushOptions::new();
 
+    log::info!("Current remote: {}", remote.url());
+
     if is_https_remote(remote.url()) {
         cbs.credentials(|_url, _username, _allowed| Cred::userpass_plaintext(&token.unwrap(), ""));
         opts.remote_callbacks(cbs);

--- a/src/git.rs
+++ b/src/git.rs
@@ -157,6 +157,14 @@ pub fn tag(config: &Config, tag_name: &str, tag_message: &str) -> Result<(), Err
     create_tag(config, &tag_name, &tag_message).map_err(Error::from)
 }
 
+pub fn get_remote_url(config: &Config, remote: &str) -> Result<Option<String>, Error> {
+    Ok(config
+        .repository
+        .find_remote(remote)?
+        .url()
+        .map(ToOwned::to_owned))
+}
+
 pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
     let repo = &config.repository;
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 
 use crate::config::Config;
 use crate::error::Error;
-use crate::error::Error::GitHub;
 use crate::USERAGENT;
 
 pub fn can_release(config: &Config) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,6 +453,7 @@ fn main() {
     log::info!("Performing preflight overrides now");
     preflight::apply_overrides(&mut config)
         .unwrap_or_else(|err| print_exit!("failed to perform preflight overrides: {}", err));
+    log::info!("Finished preflight overrides");
 
     let version = toml_file::read_from_file(&config.repository_path)
         .unwrap_or_else(|err| print_exit!("Reading `Cargo.toml` failed: {:?}", err));

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ use std::time::Duration;
 use std::{env, fs};
 use utils::user_repo_from_url;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const USERAGENT: &'static str = concat!("semantic-rs/", env!("CARGO_PKG_VERSION"));
 
 const COMMITTER_ERROR_MESSAGE: &'static str = r"
@@ -378,9 +377,9 @@ fn main() {
     log::info!("semantic.rs 🚀");
 
     let clap_args =  App::new("semantic-rs")
-        .version(VERSION)
-        .author("Jan Schulte <hello@unexpected-code> & Jan-Erik Rediger <janerik@fnordig.de>")
-        .about("Crate publishing done right")
+        .version(clap::crate_version!())
+        .author(clap::crate_authors!())
+        .about(clap::crate_description!())
         .arg(Arg::with_name("write")
              .short("w")
              .long("write")

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ fn assemble_configuration(args: ArgMatches) -> Result<config::Config, error::Err
         None => false,
     };
 
-    let force_https_flag = args.is_present("force_https");
+    let force_https_flag = args.is_present("force-https");
     config_builder.force_https(force_https_flag);
 
     // We can only release, if we are allowed to write
@@ -414,7 +414,7 @@ fn main() {
             .multiple(true))
         .arg(Arg::with_name("force-https")
             .long("force-https")
-            .help("Force https remote (will rewrite git:// remote with https://")
+            .help("Force https remote (will rewrite git:// remote with https://)")
             .takes_value(false))
         .get_matches();
 

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -22,8 +22,10 @@ pub fn check(config: &Config) -> Vec<String> {
         match remote_url {
             Ok(Some(remote_url)) => {
                 log::info!("Current remote: {}({})", remote_name, remote_url);
-                if git::is_https_remote(Some(&remote_url)) && !config.force_https {
-                    warnings.push("Git remote is not HTTPS: the publishing will fail if your environment doesn't hold your git ssh keys".into());
+                if !git::is_https_remote(Some(&remote_url)) && !config.force_https {
+                    warnings.push("Git remote is not HTTPS:".into());
+                    warnings.push("The publishing will fail if your environment doesn't hold your git ssh keys".into());
+                    warnings.push("Consider adding --force-https flag, that's most likely what you want if you're using GH_TOKEN authentication".into());
                 }
             }
             Ok(None) => log::info!("Current remote: {}", remote_name),

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -12,13 +12,19 @@ pub fn check(config: &Config) -> Vec<String> {
     }
 
     if let Err(ref err) = config.remote {
-        warnings.push(format!(
-            "Could not determine the origin remote url: {:?}",
-            err
-        ));
+        warnings.push(format!("Could not determine the origin remote: {:?}", err));
         warnings.push("semantic-rs can't push changes or create a release on GitHub".into());
     } else {
-        log::info!("Current remote: {}", config.remote.as_ref().unwrap());
+        let remote_name = config.remote.as_ref().unwrap();
+        let remote_url = crate::git::get_remote_url(config, remote_name);
+        match remote_url {
+            Ok(Some(remote_url)) => log::info!("Current remote: {}({})", remote_name, remote_url),
+            Ok(None) => log::info!("Current remote: {}", remote_name),
+            Err(err) => warnings.push(format!(
+                "Could not determine the origin remote url: {}",
+                err
+            )),
+        }
     }
 
     warnings

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -77,7 +77,16 @@ pub fn apply_overrides(config: &mut Config) -> Result<(), Error> {
                 std::process::exit(1);
             }
 
-            git::set_remote_url(config, &remote_name, new_url.as_ref().unwrap())?;
+            match new_url {
+                None => {
+                    log::error!("{} is not supported for https forcing, please consider opening an issue at https://github.com/etclabscore/semantic-rs/issues/new/choose", remote_url);
+                    std::process::exit(1);
+                }
+                Some(new_url) => {
+                    log::info!("Overriding git remote url: {} -> {}", remote_url, new_url);
+                    git::set_remote_url(config, &remote_name, &new_url)?;
+                }
+            }
         }
     }
 

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -1,4 +1,6 @@
 use crate::config::Config;
+use crate::error::Error;
+use crate::git;
 
 pub fn check(config: &Config) -> Vec<String> {
     let mut warnings = vec![];
@@ -18,7 +20,12 @@ pub fn check(config: &Config) -> Vec<String> {
         let remote_name = config.remote.as_ref().unwrap();
         let remote_url = crate::git::get_remote_url(config, remote_name);
         match remote_url {
-            Ok(Some(remote_url)) => log::info!("Current remote: {}({})", remote_name, remote_url),
+            Ok(Some(remote_url)) => {
+                log::info!("Current remote: {}({})", remote_name, remote_url);
+                if git::is_https_remote(Some(&remote_url)) && !config.force_https {
+                    warnings.push("Git remote is not HTTPS: the publishing will fail if your environment doesn't hold your git ssh keys".into());
+                }
+            }
             Ok(None) => log::info!("Current remote: {}", remote_name),
             Err(err) => warnings.push(format!(
                 "Could not determine the origin remote url: {}",
@@ -28,4 +35,49 @@ pub fn check(config: &Config) -> Vec<String> {
     }
 
     warnings
+}
+
+pub fn apply_overrides(config: &mut Config) -> Result<(), Error> {
+    if config.force_https {
+        let remote_name = config.remote.clone().unwrap();
+        let remote_url = config
+            .repository
+            .find_remote(&remote_name)?
+            .url()
+            .map(str::to_string);
+
+        let remote_url = remote_url.unwrap_or_else(|| {
+            log::error!(
+                "remote url for {} is not found in the repository",
+                remote_name
+            );
+            std::process::exit(1);
+        });
+
+        if !git::is_https_remote(Some(&remote_url)) {
+            // TODO: replace with generic regex
+            let rules = [
+                ("git@github.com:", "https://github.com/"),
+                ("git://github.com/", "https://github.com/"),
+            ];
+
+            let mut new_url = None;
+
+            for (pattern, substitute) in &rules {
+                if remote_url.starts_with(pattern) {
+                    new_url = Some(remote_url.replace(pattern, substitute));
+                    break;
+                }
+            }
+
+            if new_url.is_none() {
+                log::error!("{} is not supported for https forcing, please consider opening an issue at https://github.com/etclabscore/semantic-rs/issues/new/choose", remote_url);
+                std::process::exit(1);
+            }
+
+            git::set_remote_url(config, &remote_name, new_url.as_ref().unwrap())?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -17,6 +17,8 @@ pub fn check(config: &Config) -> Vec<String> {
             err
         ));
         warnings.push("semantic-rs can't push changes or create a release on GitHub".into());
+    } else {
+        log::info!("Current remote: {}", config.remote.as_ref().unwrap());
     }
 
     warnings


### PR DESCRIPTION
A lot of fixes connected to git and github publishing, and a few new features:
 - More platform-specific CI job names
 - Logging of a current remote
 - `--force-https` flag for remote rewriting (would convert git remote to an https one)