### PR TITLE
refactor: remove rc and refcell

### DIFF
--- a/src/plugin/dispatcher.rs
+++ b/src/plugin/dispatcher.rs
@@ -14,50 +14,79 @@ use crate::plugin::{Plugin, PluginInterface};
 
 pub struct PluginDispatcher {
     config: CfgMap,
-    map: Map<PluginStep, Vec<Plugin>>,
+    plugins: Vec<Plugin>,
+    map: Map<PluginStep, Vec<usize>>,
 }
 
 impl PluginDispatcher {
-    pub fn new(config: CfgMap, map: Map<PluginStep, Vec<Plugin>>) -> Self {
-        PluginDispatcher { config, map }
+    pub fn new(config: CfgMap, plugins: Vec<Plugin>, map: Map<PluginStep, Vec<usize>>) -> Self {
+        PluginDispatcher {
+            config,
+            plugins,
+            map,
+        }
     }
 
-    fn dispatch<RFR: Debug>(
-        &self,
+    fn dispatch<R, F>(
+        &mut self,
         step: PluginStep,
-        call_fn: impl Fn(&mut dyn PluginInterface) -> PluginResponse<RFR>,
-    ) -> DispatchedMultiResult<PluginResponse<RFR>> {
-        let mut response_map = Map::new();
-
-        if let Some(plugins) = self.mapped_plugins(step) {
-            for mut plugin in plugins {
-                log::info!("Invoking plugin '{}'", plugin.name);
-                let response = call_fn(&mut **plugin.as_interface_mut());
-                log::debug!("{}: {:?}", plugin.name, response);
-                response_map.insert(plugin.name.clone(), response);
-            }
-        }
+        mut call_fn: F,
+    ) -> DispatchedMultiResult<PluginResponse<R>>
+    where
+        R: Debug,
+        F: FnMut(&mut dyn PluginInterface) -> PluginResponse<R>,
+    {
+        let response_map = self
+            .map_plugins(step, |p| {
+                log::info!("Invoking plugin '{}'", p.name);
+                let response = call_fn(p.as_interface_mut());
+                log::debug!("{}: {:?}", p.name, response);
+                (p.name.clone(), response)
+            })
+            .collect();
 
         Ok(response_map)
     }
 
-    fn dispatch_singleton<RFR: Debug>(
-        &self,
+    fn dispatch_singleton<R, F>(
+        &mut self,
         step: PluginStep,
-        call_fn: impl FnOnce(&mut dyn PluginInterface) -> PluginResponse<RFR>,
-    ) -> DispatchedSingletonResult<PluginResponse<RFR>> {
-        let mut plugin = self.mapped_singleton(step);
-        log::info!("Invoking singleton '{}'", plugin.name);
-        let response = call_fn(&mut **plugin.as_interface_mut());
-        log::debug!("{}: {:?}", plugin.name, response);
-        Ok((plugin.name.clone(), response))
+        call_fn: F,
+    ) -> DispatchedSingletonResult<PluginResponse<R>>
+    where
+        R: Debug,
+        F: FnOnce(&mut dyn PluginInterface) -> PluginResponse<R>,
+    {
+        let name_and_response = self.map_singleton(step, |p| {
+            log::info!("Invoking singleton '{}'", p.name);
+            let response = call_fn(p.as_interface_mut());
+            log::debug!("{}: {:?}", p.name, response);
+            (p.name.clone(), response)
+        });
+
+        Ok(name_and_response)
     }
 
-    fn mapped_plugins(&self, step: PluginStep) -> Option<impl Iterator<Item = Plugin> + '_> {
-        self.map.get(&step).map(|plugins| plugins.iter().cloned())
+    fn map_plugins<'a, F, R>(
+        &'a mut self,
+        step: PluginStep,
+        mut map_fn: F,
+    ) -> impl Iterator<Item = R> + 'a
+    where
+        F: FnMut(&mut Plugin) -> R + 'a,
+    {
+        self.map
+            .get(&step)
+            .map(Vec::clone)
+            .into_iter()
+            .flat_map(|ids| ids.into_iter())
+            .map(move |id| map_fn(&mut self.plugins[id]))
     }
 
-    fn mapped_singleton(&self, step: PluginStep) -> Plugin {
+    fn map_singleton<F, R>(&mut self, step: PluginStep, map_fn: F) -> R
+    where
+        F: FnOnce(&mut Plugin) -> R,
+    {
         let no_plugins_found_panic = || {
             panic!(
                 "no plugins matching the singleton step {:?}: this is a bug, aborting.",
@@ -71,17 +100,17 @@ impl PluginDispatcher {
             )
         };
 
-        let plugins = self.map.get(&step).unwrap_or_else(no_plugins_found_panic);
+        let ids = self.map.get(&step).unwrap_or_else(no_plugins_found_panic);
 
-        if plugins.is_empty() {
+        if ids.is_empty() {
             no_plugins_found_panic();
         }
 
-        if plugins.len() != 1 {
+        if ids.len() != 1 {
             too_many_plugins_panic();
         }
 
-        plugins[0].clone()
+        map_fn(&mut self.plugins[ids[0]])
     }
 }
 
@@ -89,75 +118,84 @@ pub type DispatchedMultiResult<T> = Result<Map<String, T>, failure::Error>;
 pub type DispatchedSingletonResult<T> = Result<(String, T), failure::Error>;
 
 impl PluginDispatcher {
-    pub fn pre_flight(&self) -> DispatchedMultiResult<response::PreFlight> {
-        self.dispatch(PluginStep::PreFlight, |p| {
-            p.pre_flight(PluginRequest::with_default_data(self.config.clone()))
+    pub fn pre_flight(&mut self) -> DispatchedMultiResult<response::PreFlight> {
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::PreFlight, move |p| {
+            p.pre_flight(PluginRequest::with_default_data(cfg.clone()))
         })
     }
 
-    pub fn get_last_release(&self) -> DispatchedSingletonResult<response::GetLastRelease> {
+    pub fn get_last_release(&mut self) -> DispatchedSingletonResult<response::GetLastRelease> {
+        let cfg = self.config.clone();
         self.dispatch_singleton(PluginStep::GetLastRelease, move |p| {
-            p.get_last_release(PluginRequest::with_default_data(self.config.clone()))
+            p.get_last_release(PluginRequest::with_default_data(cfg))
         })
     }
 
     pub fn derive_next_version(
-        &self,
+        &mut self,
         current_version: Version,
     ) -> DispatchedMultiResult<response::DeriveNextVersion> {
-        self.dispatch(PluginStep::DeriveNextVersion, |p| {
-            p.derive_next_version(PluginRequest::new(
-                self.config.clone(),
-                current_version.clone(),
-            ))
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::DeriveNextVersion, move |p| {
+            p.derive_next_version(PluginRequest::new(cfg.clone(), current_version.clone()))
         })
     }
 
     pub fn generate_notes(
-        &self,
+        &mut self,
         params: request::GenerateNotesData,
     ) -> DispatchedMultiResult<response::GenerateNotes> {
-        self.dispatch(PluginStep::GenerateNotes, |p| {
-            p.generate_notes(PluginRequest::new(self.config.clone(), params.clone()))
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::GenerateNotes, move |p| {
+            p.generate_notes(PluginRequest::new(cfg.clone(), params.clone()))
         })
     }
 
     pub fn prepare(
-        &self,
+        &mut self,
         params: request::PrepareData,
     ) -> DispatchedMultiResult<response::Prepare> {
-        self.dispatch(PluginStep::Prepare, |p| {
-            p.prepare(PluginRequest::new(self.config.clone(), params.clone()))
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::Prepare, move |p| {
+            p.prepare(PluginRequest::new(cfg.clone(), params.clone()))
         })
     }
 
-    pub fn verify_release(&self) -> DispatchedMultiResult<response::VerifyRelease> {
-        self.dispatch(PluginStep::VerifyRelease, |p| {
-            p.verify_release(PluginRequest::with_default_data(self.config.clone()))
+    pub fn verify_release(&mut self) -> DispatchedMultiResult<response::VerifyRelease> {
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::VerifyRelease, move |p| {
+            p.verify_release(PluginRequest::with_default_data(cfg.clone()))
         })
     }
 
     pub fn commit(
-        &self,
+        &mut self,
         params: request::CommitData,
     ) -> DispatchedSingletonResult<response::Commit> {
+        let cfg = self.config.clone();
         self.dispatch_singleton(PluginStep::Commit, move |p| {
-            p.commit(PluginRequest::new(self.config.clone(), params))
+            p.commit(PluginRequest::new(cfg, params))
         })
     }
 
     pub fn publish(
-        &self,
+        &mut self,
         params: request::PublishData,
     ) -> DispatchedMultiResult<response::Publish> {
-        self.dispatch(PluginStep::Publish, |p| {
-            p.publish(PluginRequest::new(self.config.clone(), params.clone()))
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::Publish, move |p| {
+            p.publish(PluginRequest::new(cfg.clone(), params.clone()))
         })
     }
 
-    pub fn notify(&self, params: request::NotifyData) -> DispatchedMultiResult<response::Notify> {
-        self.dispatch(PluginStep::Notify, |p| {
-            p.notify(PluginRequest::new(self.config.clone(), params))
+    pub fn notify(
+        &mut self,
+        params: request::NotifyData,
+    ) -> DispatchedMultiResult<response::Notify> {
+        let cfg = self.config.clone();
+        self.dispatch(PluginStep::Notify, move |p| {
+            p.notify(PluginRequest::new(cfg.clone(), params))
         })
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -9,8 +9,6 @@ pub use self::dispatcher::PluginDispatcher;
 pub use self::traits::PluginInterface;
 
 use serde::{Deserialize, Serialize};
-use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
 
 pub struct RawPlugin {
     name: String,
@@ -41,28 +39,24 @@ pub enum RawPluginState {
     Started(Plugin),
 }
 
-#[derive(Clone)]
 pub struct Plugin {
     pub name: String,
-    call: Rc<RefCell<Box<dyn PluginInterface>>>,
+    call: Box<dyn PluginInterface>,
 }
 
 impl Plugin {
     pub fn new(plugin: Box<dyn PluginInterface>) -> Result<Self, failure::Error> {
         let name = plugin.name()?;
-        let plugin = Plugin {
-            name,
-            call: Rc::new(RefCell::new(plugin)),
-        };
+        let plugin = Plugin { name, call: plugin };
         Ok(plugin)
     }
 
-    pub fn as_interface(&self) -> Ref<Box<dyn PluginInterface>> {
-        RefCell::borrow(&self.call)
+    pub fn as_interface(&self) -> &dyn PluginInterface {
+        &*self.call
     }
 
-    pub fn as_interface_mut(&mut self) -> RefMut<Box<dyn PluginInterface>> {
-        RefCell::borrow_mut(&self.call)
+    pub fn as_interface_mut(&mut self) -> &mut dyn PluginInterface {
+        &mut *self.call
     }
 }
 


### PR DESCRIPTION
Just 4 history: unfortunately puzzle of getting away without RefCell __and__ exhaustive cloning in `Dispatcher` stays unsolved.