### PR TITLE
Feat: Publishing to Docker repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,8 @@ jobs:
             rustup component add clippy --toolchain $TOOLCHAIN
             rustup component add rustfmt --toolchain stable
       - run: cargo +$TOOLCHAIN test --all
-      - save_cache: *save-deps-cache-ubuntu
       - run: cargo +$TOOLCHAIN clippy
-      - save_cache: *save-deps-cache-rust
+      - save_cache: *save-deps-cache-ubuntu
       - run: cargo +stable fmt -- --check
 
   build-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
       - run: cargo +$TOOLCHAIN test --all
       - save_cache: *save-deps-cache-ubuntu
       - run: cargo +$TOOLCHAIN clippy
+      - save_cache: *save-deps-cache-rust
       - run: cargo +stable fmt -- --check
 
   build-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ aliases:
     branches:
       only:  /^(pull|fix|feat|chore)\/.*$/
   # -------------------------
-  # ALIASES: Get latest usable nightly from rustup-components-history
+  # ALIASES: Utility commands DRY
   - &get-latest-toolchain
     name: Get latest Nightly version that has Clippy component
     command: |
@@ -51,6 +51,14 @@ aliases:
       echo "export TOOLCHAIN=$TOOLCHAIN" >> $BASH_ENV
       source $BASH_ENV
       echo Would use toolchain $TOOLCHAIN
+  - &setup-docker
+    name: Setup docker environment
+    command: |
+      export DOCKERVERSION="18.09.6"
+      curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz
+      tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 -C /usr/local/bin docker/docker
+      rm docker-${DOCKERVERSION}.tgz
+      docker --version
 
 
 defaults: &defaults
@@ -195,6 +203,8 @@ jobs:
     docker:
       - image: rust:latest
     steps:
+      - setup_remote_docker
+      - run: *setup-docker
       - checkout
       - attach_workspace:
           at: /workspace
@@ -205,6 +215,8 @@ jobs:
     docker:
       - image: rust:latest
     steps:
+      - setup_remote_docker
+      - run: *setup-docker
       - checkout
       - attach_workspace:
           at: /workspace

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,59 @@
+FROM rust:latest
+
+# REQUIRED ENV VARS
+
+# git repository url
+ARG REPO_URL
+
+# git repository branch
+ARG REPO_BRANCH
+
+# build command to run
+ARG BUILD_CMD
+
+# command to execute
+ARG EXEC_CMD
+ENV EXEC=$EXEC_CMD
+
+# OPTIONAL ENV VARS
+
+# relative path to the binary file (would be copied to /bin/)
+ARG BINARY_PATH=""
+
+# whether to cleanup the build
+ARG CLEANUP=false
+
+# Install dependencies
+RUN apt-get update && apt-get install -y git cmake
+
+# Create user and set workdir
+RUN useradd -ms /bin/bash semantic
+USER semantic
+WORKDIR /home/semantic/
+
+# Clone the repo
+RUN git clone --recursive $REPO_URL project
+WORKDIR /home/semantic/project
+
+# Checkout branch
+RUN git checkout $REPO_BRANCH
+
+# Run build command
+RUN bash -c "$BUILD_CMD"
+
+# Change back to root user
+USER root
+
+# Optionally copy binary to /bin/
+RUN if [ -f $BINARY_PATH ]; then cp $BINARY_PATH /bin/; fi
+
+# Optional cleanup
+RUN if $CLEANUP; then rm -rf /home/semantic/project; fi
+
+# Switch back to user semantic and set a workdir for a volume mountpoint
+USER semantic
+RUN mkdir /home/semantic/workdir
+WORKDIR /home/semantic/workdir
+
+# Run cmd
+CMD $EXEC

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ features = ['derive']
 [dependencies.linked-hash-map]
 version = '0.5'
 features = ['serde_impl']
+
 [profile.release]
 debug = true
 overflow-checks = true

--- a/README.md
+++ b/README.md
@@ -295,6 +295,69 @@ ignore = [
 ]
 ```
 
+
+### Docker
+
+Docker Plugin calls the docker client in order to 
+ - Build
+ - Tag
+ - And publish images to Docker Repository
+
+Currently only publishing to DockerHub is supported (#41)
+
+##### Plugins Table Example
+
+```toml
+[plugins]
+docker = "builtin"
+```
+
+##### Methods
+
+| Step                | Description                                                                                                                     |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| Pre Flight          | Check configuration and DOCKER_USER / DOCKER_PASSWORD env vars                                                                  |
+| Prepare             | Store the next version in internal state (temporary, will be changed)                                                           |
+| Publish             | Build, tag and publish image to the repository                                                                                  |
+
+
+##### Configuration
+
+Main configuration
+
+```toml
+[cfg.docker]
+# Clonable repository url
+repo_url = "https://github.com/etclabscore/semantic-rs.git"
+# Branch to build for image generation
+repo_branch = "master"
+```
+
+Setup images
+ 
+```toml
+[[cfg.docker.images]]
+# Registry to be used: dockerhub or URL
+registry = "dockerhub"
+# Namespace of the image (the part before the name)
+# e.g etclabscore is a namespace in etclabscore/semantic-rs:latest
+namespace = "etclabscore"
+# Name of the image
+name = "semantic-rs"
+# Default image tag to use in addition to the version
+tag = "latest"
+# Source Dockerfile
+dockerfile = ".docker/Dockerfile"
+# Path of a binary to run, will be copied into /bin/
+binary_path = "target/release/semantic-rs"
+# Whether to remove intermediate build artifacts
+cleanup = true
+# Command to build the project
+build_cmd = "cargo build --release"
+# Binary to run as a container CMD
+exec_cmd = "/bin/semantic-rs"
+```
+
 ## Development
 
 Requirements:

--- a/releaserc.toml
+++ b/releaserc.toml
@@ -50,4 +50,19 @@ assets = [
     "Changelog.md"
 ]
 
+[cfg.docker]
+repo_url = "https://github.com/etclabscore/semantic-rs.git"
+repo_branch = "master"
+registry = "dockerhub"
+organization = "etclabscore"
+dockerfile = ".docker/Dockerfile"
+
+[[cfg.docker.images]]
+name = "semantic-rs"
+tag = "latest"
+binary_path = "target/release/semantic-rs"
+cleanup = true
+build_cmd = "cargo build --release"
+exec_cmd = "/bin/semantic-rs"
+
 

--- a/releaserc.toml
+++ b/releaserc.toml
@@ -53,11 +53,11 @@ assets = [
 [cfg.docker]
 repo_url = "https://github.com/etclabscore/semantic-rs.git"
 repo_branch = "master"
-registry = "dockerhub"
-organization = "etclabscore"
-dockerfile = ".docker/Dockerfile"
 
 [[cfg.docker.images]]
+registry = "dockerhub"
+namespace = "etclabscore"
+dockerfile = ".docker/Dockerfile"
 name = "semantic-rs"
 tag = "latest"
 binary_path = "target/release/semantic-rs"

--- a/releaserc.toml
+++ b/releaserc.toml
@@ -5,6 +5,7 @@ git = { location = "builtin" }
 clog = "builtin"
 github = "builtin"
 rust = "builtin"
+docker = "builtin"
 
 [steps]
 # Shared step
@@ -19,13 +20,13 @@ derive_next_version = [ "clog" ]
 # the succession of runs in this case will be determined by the succession in the `plugins` list
 generate_notes = "clog"
 # Prepare the release (pre-release step for intermediate artifacts generation)
-prepare = ["clog", "rust"]
+prepare = "discover"
 # Check the release before publishing
-verify_release = ["rust"]
+verify_release = "discover"
 # Commit & push changes to the VCS
 commit = "git"
 # Publish to various platforms
-publish = [ "github" ]
+publish = [ "github", "docker" ]
 # Post-release step to notify users about release (e.g leave comments in issues resolved in this release)
 notify = "discover"
 

--- a/src/builtin_plugins/docker.rs
+++ b/src/builtin_plugins/docker.rs
@@ -114,14 +114,6 @@ impl PluginInterface for DockerPlugin {
             state.version.replace(req.data.clone());
         }
 
-        for image in &cfg.images {
-            build_image(&cfg, image)?;
-
-            let from = format!("{}:{}", image.name, image.tag);
-            tag_image(&from, &get_image_path(image, &image.tag))?;
-            tag_image(&from, &get_image_path(image, &req.data.to_string()))?;
-        }
-
         PluginResponse::from_ok(vec![])
     }
 
@@ -149,6 +141,14 @@ impl PluginInterface for DockerPlugin {
         login(registry_url, &credentials)?;
 
         for image in &cfg.images {
+            build_image(&cfg, image)?;
+
+            // Tag as namespace/name/tag and namespace/name/version
+            let from = format!("{}:{}", image.name, image.tag);
+            tag_image(&from, &get_image_path(image, &image.tag))?;
+            tag_image(&from, &get_image_path(image, &version))?;
+
+            // Publish namespace/name/tag and namespace/name/version
             push_image(image, &image.tag)?;
             push_image(image, &version)?;
         }

--- a/src/builtin_plugins/docker.rs
+++ b/src/builtin_plugins/docker.rs
@@ -1,0 +1,67 @@
+use std::ops::Try;
+
+use failure::Fail;
+
+use crate::config::CfgMapExt;
+use crate::plugin::proto::{
+    request,
+    response::{self, PluginResponse},
+};
+use crate::plugin::{PluginInterface, PluginStep};
+
+#[derive(Default)]
+pub struct DockerPlugin {
+    cfg: Option<Config>,
+    state: Option<State>,
+}
+
+impl DockerPlugin {
+    pub fn new() -> Self {
+        DockerPlugin::default()
+    }
+}
+
+struct Config {
+
+}
+
+struct State {
+
+}
+
+impl PluginInterface for DockerPlugin {
+    fn name(&self) -> response::Name {
+        PluginResponse::from_ok("docker".into())
+    }
+
+    fn methods(&self, req: request::Methods) -> response::Methods {
+        PluginResponse::from_ok(vec![
+            PluginStep::PreFlight,
+            PluginStep::Prepare,
+            PluginStep::VerifyRelease,
+            PluginStep::Publish,
+        ])
+    }
+
+    fn pre_flight(&mut self, req: request::PreFlight) -> response::PreFlight {
+        unimplemented!()
+    }
+
+    fn prepare(&mut self, req: request::Prepare) -> response::Prepare {
+        unimplemented!()
+    }
+
+    fn verify_release(&mut self, req: request::VerifyRelease) -> response::VerifyRelease {
+        unimplemented!()
+    }
+
+    fn publish(&mut self, req: request::Publish) -> response::Publish {
+        unimplemented!()
+    }
+}
+
+#[derive(Fail, Debug)]
+enum DockerPluginError {
+    #[fail(display = "docker repo credentials are not defined, cannot push the image")]
+    CredentialsUndefined,
+}

--- a/src/builtin_plugins/docker.rs
+++ b/src/builtin_plugins/docker.rs
@@ -1,4 +1,8 @@
+use std::fmt::{Debug, Display};
+use std::io::Write;
 use std::ops::Try;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
 
 use failure::Fail;
 
@@ -6,8 +10,10 @@ use crate::config::CfgMapExt;
 use crate::plugin::proto::{
     request,
     response::{self, PluginResponse},
+    Error,
 };
 use crate::plugin::{PluginInterface, PluginStep};
+use serde::Deserialize;
 
 #[derive(Default)]
 pub struct DockerPlugin {
@@ -21,12 +27,43 @@ impl DockerPlugin {
     }
 }
 
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
 struct Config {
+    repo_url: String,
+    repo_branch: String,
+    host: Option<String>,
+    registry: Registry,
+    dockerfile: PathBuf,
+    images: Vec<Image>,
+}
 
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+struct Image {
+    namespace: Option<String>,
+    name: String,
+    tag: String,
+    binary_path: String,
+    build_cmd: String,
+    exec_cmd: String,
+    cleanup: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+enum Registry {
+    Dockerhub,
 }
 
 struct State {
+    credentials: Option<Credentials>,
+    version: Option<semver::Version>,
+}
 
+struct Credentials {
+    username: String,
+    password: String,
 }
 
 impl PluginInterface for DockerPlugin {
@@ -38,30 +75,203 @@ impl PluginInterface for DockerPlugin {
         PluginResponse::from_ok(vec![
             PluginStep::PreFlight,
             PluginStep::Prepare,
-            PluginStep::VerifyRelease,
             PluginStep::Publish,
         ])
     }
 
     fn pre_flight(&mut self, req: request::PreFlight) -> response::PreFlight {
-        unimplemented!()
+        let mut response = PluginResponse::builder();
+
+        let cfg: Config = toml::Value::Table(req.cfg_map.get_sub_table("docker")?).try_into()?;
+        self.cfg.replace(cfg);
+
+        let credentials = {
+            let user = std::env::var("DOCKER_USER").ok();
+            let password = std::env::var("DOCKER_PASSWORD").ok();
+            user.and_then(|username| password.map(|password| Credentials { username, password }))
+        };
+
+        if credentials.is_none() {
+            response.warning(
+                "Docker registry credentials are undefined: won't be able to push the image",
+            );
+            response.warning("Please set DOCKER_USER and DOCKER_PASSWORD env vars");
+        }
+
+        self.state.replace(State {
+            credentials,
+            version: None,
+        });
+
+        response.body(()).build()
     }
 
     fn prepare(&mut self, req: request::Prepare) -> response::Prepare {
-        unimplemented!()
-    }
+        let cfg = self.cfg.as_ref().ok_or(DockerPluginError::MissingState)?;
 
-    fn verify_release(&mut self, req: request::VerifyRelease) -> response::VerifyRelease {
-        unimplemented!()
+        {
+            let state = self.state.as_mut().ok_or(DockerPluginError::MissingState)?;
+            state.version.replace(req.data.clone());
+        }
+
+        for image in &cfg.images {
+            build_image(&cfg, image)?;
+
+            let from = format!("{}:{}", image.name, image.tag);
+            tag_image(&from, &get_image_path(image, &image.tag))?;
+            tag_image(&from, &get_image_path(image, &req.data.to_string()))?;
+        }
+
+        PluginResponse::from_ok(vec![])
     }
 
     fn publish(&mut self, req: request::Publish) -> response::Publish {
-        unimplemented!()
+        let cfg = self.cfg.as_ref().ok_or(DockerPluginError::MissingState)?;
+
+        let state = self.state.as_ref().ok_or(DockerPluginError::MissingState)?;
+
+        let credentials = state
+            .credentials
+            .as_ref()
+            .ok_or(DockerPluginError::CredentialsUndefined)?;
+
+        let version = state
+            .version
+            .as_ref()
+            .ok_or(DockerPluginError::MissingVersion)?;
+
+        let version = version.to_string();
+
+        let registry_url = match cfg.registry {
+            Registry::Dockerhub => None,
+        };
+
+        login(registry_url, &credentials)?;
+
+        for image in &cfg.images {
+            push_image(image, &image.tag)?;
+            push_image(image, &version)?;
+        }
+
+        PluginResponse::from_ok(())
     }
+}
+
+fn get_image_path(image: &Image, tag: &str) -> String {
+    if let Some(namespace) = image.namespace.as_ref() {
+        format!("{}/{}:{}", namespace, image.name, tag)
+    } else {
+        format!("{}:{}", image.name, tag)
+    }
+}
+
+fn build_image(cfg: &Config, image: &Image) -> Result<(), failure::Error> {
+    let mut cmd = Command::new("docker");
+
+    cmd.arg("build").arg(".docker").arg("--no-cache");
+
+    // Set filename of Dockerfile
+    cmd.arg("-f").arg(&cfg.dockerfile.display().to_string());
+
+    // Set name and tag
+    cmd.arg("-t").arg(&format!("{}:{}", image.name, image.tag));
+
+    let mut set_env_var = |k, v: &dyn Display| {
+        cmd.arg("--build-arg").arg(format!("{}={}", k, v));
+    };
+
+    // Set env vars
+    set_env_var("REPO_URL", &cfg.repo_url);
+    set_env_var("REPO_BRANCH", &cfg.repo_branch);
+    set_env_var("BUILD_CMD", &image.build_cmd);
+    set_env_var("BINARY_PATH", &image.binary_path);
+    set_env_var("CLEANUP", &image.cleanup);
+    set_env_var("EXEC_CMD", &image.exec_cmd);
+
+    log::debug!("exec {:?}", cmd);
+
+    let status = cmd.status()?;
+    if !status.success() {
+        Err(DockerPluginError::DockerReturnedError(status.code()))?
+    }
+
+    log::info!("Built image {}:{}", image.name, image.tag);
+
+    Ok(())
+}
+
+fn tag_image(from: &str, to: &str) -> Result<(), failure::Error> {
+    log::info!("tagging image {} as {}", from, to);
+
+    let mut cmd = Command::new("docker");
+
+    let status = cmd.arg("tag").arg(from).arg(to).status()?;
+
+    if !status.success() {
+        Err(DockerPluginError::DockerReturnedError(status.code()))?
+    }
+
+    Ok(())
+}
+
+fn login(registry_url: Option<&str>, credentials: &Credentials) -> Result<(), failure::Error> {
+    log::info!("logging in as {}", credentials.username);
+
+    let mut cmd = Command::new("docker");
+
+    cmd.arg("login")
+        .arg("--username")
+        .arg(&credentials.username)
+        .arg("--password-stdin");
+
+    if let Some(url) = registry_url {
+        cmd.arg(url);
+    }
+
+    let mut child = cmd.stdin(Stdio::piped()).spawn()?;
+
+    {
+        let mut stdin = child.stdin.as_mut().ok_or(DockerPluginError::StdioError)?;
+        stdin.write_all(credentials.password.as_bytes())?;
+    }
+
+    let status = child.wait()?;
+
+    if !status.success() {
+        Err(DockerPluginError::DockerReturnedError(status.code()))?
+    }
+
+    Ok(())
+}
+
+fn push_image(image: &Image, tag: &str) -> Result<(), failure::Error> {
+    let mut cmd = Command::new("docker");
+
+    cmd.arg("push");
+
+    let path = get_image_path(image, tag);
+    log::info!("Publishing image {}", path);
+    cmd.arg(path);
+
+    let status = cmd.status()?;
+
+    if !status.success() {
+        Err(DockerPluginError::DockerReturnedError(status.code()))?
+    }
+
+    Ok(())
 }
 
 #[derive(Fail, Debug)]
 enum DockerPluginError {
-    #[fail(display = "docker repo credentials are not defined, cannot push the image")]
+    #[fail(display = "DOCKER_USER or DOCKER_PASSWORD are not set, cannot push the image.")]
     CredentialsUndefined,
+    #[fail(display = "state is missing: forgot to call pre_flight?")]
+    MissingState,
+    #[fail(display = "version is missing: forgot to call prepare?")]
+    MissingVersion,
+    #[fail(display = "docker command exited with error {:?}", _0)]
+    DockerReturnedError(Option<i32>),
+    #[fail(display = "stdio error: failed to pass password to docker process via stdin")]
+    StdioError,
 }

--- a/src/builtin_plugins/mod.rs
+++ b/src/builtin_plugins/mod.rs
@@ -2,6 +2,7 @@ pub mod clog;
 pub mod git;
 pub mod github;
 pub mod rust;
+pub mod docker;
 
 pub use self::clog::ClogPlugin;
 pub use self::git::GitPlugin;

--- a/src/builtin_plugins/mod.rs
+++ b/src/builtin_plugins/mod.rs
@@ -1,8 +1,8 @@
 pub mod clog;
+pub mod docker;
 pub mod git;
 pub mod github;
 pub mod rust;
-pub mod docker;
 
 pub use self::clog::ClogPlugin;
 pub use self::git::GitPlugin;

--- a/src/plugin/resolver.rs
+++ b/src/plugin/resolver.rs
@@ -1,7 +1,7 @@
 use failure::Fail;
 
-use crate::plugin::{PluginInterface, RawPlugin, RawPluginState, ResolvedPlugin, UnresolvedPlugin};
 use crate::builtin_plugins::docker::DockerPlugin;
+use crate::plugin::{PluginInterface, RawPlugin, RawPluginState, ResolvedPlugin, UnresolvedPlugin};
 
 pub struct PluginResolver {
     builtin: BuiltinResolver,

--- a/src/plugin/resolver.rs
+++ b/src/plugin/resolver.rs
@@ -1,6 +1,7 @@
 use failure::Fail;
 
 use crate::plugin::{PluginInterface, RawPlugin, RawPluginState, ResolvedPlugin, UnresolvedPlugin};
+use crate::builtin_plugins::docker::DockerPlugin;
 
 pub struct PluginResolver {
     builtin: BuiltinResolver,
@@ -60,6 +61,7 @@ impl Resolver for BuiltinResolver {
             "github" => Box::new(GithubPlugin::new()),
             "clog" => Box::new(ClogPlugin::new()),
             "rust" => Box::new(RustPlugin::new()),
+            "docker" => Box::new(DockerPlugin::new()),
             other => Err(ResolverError::BuiltinNotRegistered(other.to_string()))?,
         };
         Ok(ResolvedPlugin::Builtin(plugin))


### PR DESCRIPTION
This PR adds another built-in plugin: `docker`

Flow:
 - Build docker image using `.docker/Dockerfile` as a template
 - Separately tag as `latest` and `next_version`
 - Publish to DockerHub

It also supports building several images for multi-binary repos.

Checked on a test crate: https://cloud.docker.com/u/mersinvald/repository/docker/mersinvald/semantic-rs-test-crate

