### PR TITLE
chore: revert adding the CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # semantic-rs
 
-[![CircleCI](https://circleci.com/gh/etclabscore/semantic-rs/tree/master.svg?style=svg)](https://circleci.com/gh/etclabscore/semantic-rs/tree/master)
 
 This tool helps people to publish crates following the [semver](http://semver.org/) specification.
 


### PR DESCRIPTION
CircleCI falsefuly treats skipped jobs as failed ones